### PR TITLE
Version 1.1.0 - refactoring, and two missing actions and presets

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -75,9 +75,9 @@ export const UpdateActions = function (self) {
 
 	// Add simple actions, using the list from refdata.js
 	for (var action in SIMPLE_ACTIONS) {
-		let id = SIMPLE_ACTIONS[action].id
+		let id = SIMPLE_ACTIONS[action].name.split(' ').join('_').toLowerCase()
 		let name = SIMPLE_ACTIONS[action].name
-		let appCommand = SIMPLE_ACTIONS[action].appCommand
+		let appCommand = SIMPLE_ACTIONS[action].appCommand ? SIMPLE_ACTIONS[action].appCommand : name.split(' ').join('')
 		actions[id] = {
 			name: name,
 			callback: async () => {

--- a/actions.js
+++ b/actions.js
@@ -1,12 +1,14 @@
+import { song_parts } from './refdata.js'
+
 export const UpdateActions = function (self) {
 	let actions = {
 		on_air_toggle: {
 			name: 'Toggle On Air',
 			callback: async () => {
-				if (self.on_air) {
-					self.sendAppCommand('GoOffAir')
+				if (self.proclaimAPI.on_air) {
+					self.proclaimAPI.sendAppCommand('GoOffAir')
 				} else {
-					self.sendAppCommand('GoOnAir')
+					self.proclaimAPI.sendAppCommand('GoOnAir')
 				}
 			},
 		},
@@ -24,7 +26,7 @@ export const UpdateActions = function (self) {
 				},
 			],
 			callback: async (event) => {
-				self.sendAppCommand('GoToServiceItem', event.options.num)
+				self.proclaimAPI.sendAppCommand('GoToServiceItem', event.options.num)
 			},
 		},
 
@@ -41,7 +43,7 @@ export const UpdateActions = function (self) {
 				},
 			],
 			callback: async (event) => {
-				self.sendAppCommand('GoToSlide', event.options.num)
+				self.proclaimAPI.sendAppCommand('GoToSlide', event.options.num)
 			},
 		},
 
@@ -53,7 +55,7 @@ export const UpdateActions = function (self) {
 					id: 'song_part',
 					label: 'Song Part',
 					default: 0,
-					choices: self.song_parts,
+					choices: song_parts,
 				},
 				{
 					id: 'item_index',
@@ -65,8 +67,8 @@ export const UpdateActions = function (self) {
 				},
 			],
 			callback: async (event) => {
-				const part = self.song_parts[event.options.song_part].label
-				self.sendAppCommand(`ShowSongLyrics${part}ByIndex`, event.options.item_index)
+				const part = song_parts[event.options.song_part].label
+				self.proclaimAPI.sendAppCommand(`ShowSongLyrics${part}ByIndex`, event.options.item_index)
 			},
 		},
 	}
@@ -135,7 +137,7 @@ export const UpdateActions = function (self) {
 		},
 	]
 
-	// Song Parts
+	// Add simple actions
 	for (var action in simpleActions) {
 		let id = simpleActions[action].id
 		let name = simpleActions[action].name
@@ -143,7 +145,7 @@ export const UpdateActions = function (self) {
 		actions[id] = {
 			name: name,
 			callback: async () => {
-				self.sendAppCommand(appCommand)
+				self.proclaimAPI.sendAppCommand(appCommand)
 			},
 		}
 	}

--- a/actions.js
+++ b/actions.js
@@ -1,4 +1,4 @@
-import { song_parts } from './refdata.js'
+import { songParts, simpleActions } from './refdata.js'
 
 export const UpdateActions = function (self) {
 	let actions = {
@@ -55,7 +55,7 @@ export const UpdateActions = function (self) {
 					id: 'song_part',
 					label: 'Song Part',
 					default: 0,
-					choices: song_parts,
+					choices: songParts,
 				},
 				{
 					id: 'item_index',
@@ -67,75 +67,11 @@ export const UpdateActions = function (self) {
 				},
 			],
 			callback: async (event) => {
-				const part = song_parts[event.options.song_part].label
+				const part = songParts[event.options.song_part].label
 				self.proclaimAPI.sendAppCommand(`ShowSongLyrics${part}ByIndex`, event.options.item_index)
 			},
 		},
 	}
-
-	const simpleActions = [
-		// On/Off Air
-		{ id: 'go_on_air', name: 'Go On Air', appCommand: 'GoOnAir' },
-		{ id: 'go_off_air', name: 'Go Off Air', appCommand: 'GoOffAir' },
-
-		// Slides
-		{ id: 'previous_slide', name: 'Previous Slide', appCommand: 'PreviousSlide' },
-		{ id: 'next_slide', name: 'Next Slide', appCommand: 'NextSlide' },
-		{ id: 'previous_service_item', name: 'Previous Service Item', appCommand: 'PreviousServiceItem' },
-		{ id: 'next_service_item', name: 'Next Service Item', appCommand: 'NextServiceItem' },
-
-		// Service Parts
-		{ id: 'start_pre_service', name: 'Start Pre Service', appCommand: 'StartPreService' },
-		{ id: 'start_warm_up', name: 'Start Warm Up', appCommand: 'StartWarmUp' },
-		{ id: 'start_service', name: 'Start Service', appCommand: 'StartService' },
-		{ id: 'start_post_service', name: 'Start Post Service', appCommand: 'StartPostService' },
-
-		// Media
-		{ id: 'next_audio_item', name: 'Next Audio Item', appCommand: 'NextAudioItem' },
-		{ id: 'previous_audio_item', name: 'Previous Audio Item', appCommand: 'PreviousPreviousAudioItem' }, // (sic.)
-		{ id: 'video_restart', name: 'Video Restart', appCommand: 'VideoRestart' },
-		// Not clear how "rewind" differs from "restart", or what "fast forward" does
-		// { id: 'video_rewind', name: 'Video Rewind', appCommand: 'VideoRestart' },
-		// { id: 'video_fast_forward', name: 'Video Fast Forward', appCommand: 'VideoFastForward' },
-		{ id: 'video_play', name: 'Video Play', appCommand: 'VideoPlay' },
-		{ id: 'video_pause', name: 'Video Pause', appCommand: 'VideoPause' },
-
-		// Quick Screens
-		{ id: 'show_blank_quick_screen', name: 'Show Blank Quick Screen', appCommand: 'ShowBlankQuickScreen' },
-		{ id: 'show_logo_quick_screen', name: 'Show Logo Quick Screen', appCommand: 'ShowLogoQuickScreen' },
-		{ id: 'show_no_text_quick_screen', name: 'Show No Text Quick Screen', appCommand: 'ShowNoTextQuickScreen' },
-		{
-			id: 'show_floating_hearts_quick_screen',
-			name: 'Show Floating Hearts Quick Screen',
-			appCommand: 'ShowFloatingHeartsQuickScreen',
-		},
-		{
-			id: 'show_floating_amens_quick_screen',
-			name: 'Show Floating Amens Quick Screen',
-			appCommand: 'ShowFloatingAmensQuickScreen',
-		},
-		{ id: 'show_amen_quick_screen', name: 'Show Amen Quick Screen', appCommand: 'ShowAmenQuickScreen' },
-		{
-			id: 'show_hallelujah_quick_screen',
-			name: 'Show Hallelujah Quick Screen',
-			appCommand: 'ShowHallelujahQuickScreen',
-		},
-		{
-			id: 'show_praise_the_lord_quick_screen',
-			name: 'Show Praise The Lord Quick Screen',
-			appCommand: 'ShowPraiseTheLordQuickScreen',
-		},
-		{
-			id: 'show_he_is_risen_quick_screen',
-			name: 'Show He Is Risen Quick Screen',
-			appCommand: 'ShowHeIsRisenQuickScreen',
-		},
-		{
-			id: 'show_he_is_risen_indeed_quick_screen',
-			name: 'Show He Is Indeed White Screen',
-			appCommand: 'ShowHeIsRisenWhiteQuickScreen', // (sic.)
-		},
-	]
 
 	// Add simple actions
 	for (var action in simpleActions) {

--- a/actions.js
+++ b/actions.js
@@ -6,9 +6,9 @@ export const UpdateActions = function (self) {
 			name: 'Toggle On Air',
 			callback: async () => {
 				if (self.proclaimAPI.on_air) {
-					self.proclaimAPI.sendAppCommand('GoOffAir')
+					await self.proclaimAPI.sendAppCommand('GoOffAir')
 				} else {
-					self.proclaimAPI.sendAppCommand('GoOnAir')
+					await self.proclaimAPI.sendAppCommand('GoOnAir')
 				}
 			},
 		},
@@ -26,7 +26,7 @@ export const UpdateActions = function (self) {
 				},
 			],
 			callback: async (event) => {
-				self.proclaimAPI.sendAppCommand('GoToServiceItem', event.options.num)
+				await self.proclaimAPI.sendAppCommand('GoToServiceItem', event.options.num)
 			},
 		},
 
@@ -43,7 +43,7 @@ export const UpdateActions = function (self) {
 				},
 			],
 			callback: async (event) => {
-				self.proclaimAPI.sendAppCommand('GoToSlide', event.options.num)
+				await self.proclaimAPI.sendAppCommand('GoToSlide', event.options.num)
 			},
 		},
 
@@ -68,7 +68,7 @@ export const UpdateActions = function (self) {
 			],
 			callback: async (event) => {
 				const part = SONG_PARTS[event.options.song_part].label
-				self.proclaimAPI.sendAppCommand(`ShowSongLyrics${part}ByIndex`, event.options.item_index)
+				await self.proclaimAPI.sendAppCommand(`ShowSongLyrics${part}ByIndex`, event.options.item_index)
 			},
 		},
 	}
@@ -81,7 +81,7 @@ export const UpdateActions = function (self) {
 		actions[id] = {
 			name: name,
 			callback: async () => {
-				self.proclaimAPI.sendAppCommand(appCommand)
+				await self.proclaimAPI.sendAppCommand(appCommand)
 			},
 		}
 	}

--- a/actions.js
+++ b/actions.js
@@ -1,4 +1,4 @@
-import { songParts, simpleActions } from './refdata.js'
+import { SONG_PARTS, SIMPLE_ACTIONS } from './refdata.js'
 
 export const UpdateActions = function (self) {
 	let actions = {
@@ -55,7 +55,7 @@ export const UpdateActions = function (self) {
 					id: 'song_part',
 					label: 'Song Part',
 					default: 0,
-					choices: songParts,
+					choices: SONG_PARTS,
 				},
 				{
 					id: 'item_index',
@@ -67,17 +67,17 @@ export const UpdateActions = function (self) {
 				},
 			],
 			callback: async (event) => {
-				const part = songParts[event.options.song_part].label
+				const part = SONG_PARTS[event.options.song_part].label
 				self.proclaimAPI.sendAppCommand(`ShowSongLyrics${part}ByIndex`, event.options.item_index)
 			},
 		},
 	}
 
-	// Add simple actions
-	for (var action in simpleActions) {
-		let id = simpleActions[action].id
-		let name = simpleActions[action].name
-		let appCommand = simpleActions[action].appCommand
+	// Add simple actions, using the list from refdata.js
+	for (var action in SIMPLE_ACTIONS) {
+		let id = SIMPLE_ACTIONS[action].id
+		let name = SIMPLE_ACTIONS[action].name
+		let appCommand = SIMPLE_ACTIONS[action].appCommand
 		actions[id] = {
 			name: name,
 			callback: async () => {

--- a/api.js
+++ b/api.js
@@ -1,0 +1,220 @@
+import { InstanceStatus } from '@companion-module/base'
+import { got } from 'got'
+
+// Handle the interaction with Proclaim
+export class ProclaimAPI {
+	// Create a new ProclaimAPI object, storing a reference back to our module instance, and setting
+	// up our state variables
+	constructor(instance) {
+		this.instance = instance
+
+		this.ip = ''
+		this.password = ''
+
+		this.on_air = false // Is Proclaim "On Air"?
+		this.on_air_session_id = '' // Proclaim On Air Session ID
+		this.on_air_successful = false // Were we able to connect to check Proclaim's On Air status?
+		this.onair_poll_interval = undefined // The interval ID for polling On Air status
+		this.proclaim_auth_required = false // Does Proclaim require authentication for App Commands?
+		this.proclaim_auth_successful = false // Were we able to authenticate to Proclaim?
+		this.proclaim_auth_token = '' // Proclaim authentication token
+	}
+
+	// Called when a new module configuration is supplied. Stash the ip and password, and
+	// initialise on-air polling
+	configure() {
+		this.ip = this.instance.config.ip
+		this.password = this.instance.config.password
+
+		// Initialise on-air polling
+		if (this.onair_poll_interval !== undefined) {
+			clearInterval(this.onair_poll_interval)
+		}
+		this.init_onair_poll()
+
+		// Does Proclaim require authentication?
+		this.proclaim_auth_required = this.ip != '127.0.0.1'
+		if (this.proclaim_auth_required) {
+			// Ask for an auth token
+			this.getAuthToken()
+		}
+	}
+
+	// When destroying, clear the interval for polling
+	destroy() {
+		if (this.onair_poll_interval !== undefined) {
+			clearInterval(this.onair_poll_interval)
+		}
+	}
+
+	// Look at the various status flags and determine the overall module connection status
+	setModuleStatus() {
+		if (!this.ip) {
+			this.instance.updateStatus(InstanceStatus.BadConfig, 'IP not specified')
+			return
+		}
+
+		if (!this.on_air_successful) {
+			this.instance.updateStatus(InstanceStatus.Disconnected, 'Could not connect to Proclaim')
+			return
+		}
+
+		if (this.proclaim_auth_required && !this.proclaim_auth_successful) {
+			this.instance.updateStatus(InstanceStatus.ConnectionFailure, 'Proclaim authentication unsuccessful')
+			return
+		}
+
+		this.instance.updateStatus(InstanceStatus.Ok)
+	}
+
+	// Set up the regular polling of on-air status
+	init_onair_poll() {
+		this.onair_poll_interval = setInterval(() => {
+			this.onair_poll()
+		}, 1000)
+		this.onair_poll()
+	}
+
+	// Poll for on-air status
+	async onair_poll() {
+		if (!this.ip) {
+			this.setModuleStatus()
+			return
+		}
+
+		const url = `http://${this.ip}:52195/onair/session`
+		const on_air_previously_successful = this.on_air_successful
+
+		try {
+			const data = await got(url, {
+				timeout: {
+					request: 1000,
+				},
+				retry: {
+					limit: 0,
+				},
+			}).text()
+
+			this.on_air_successful = true
+
+			// If we got a session ID back, we're on air! If we got blank, we're off air
+			if (data.length > 30) {
+				this.on_air = true
+				this.on_air_session_id = data
+				this.instance.setVariableValues({
+					on_air: true,
+				})
+			} else {
+				this.on_air = false
+				this.on_air_session_id = ''
+				this.instance.setVariableValues({
+					on_air: false,
+				})
+			}
+			this.instance.checkFeedbacks('on_air')
+			this.setModuleStatus()
+
+			// If Proclaim is now responding and wasn't previously, try to authenticate
+			if (this.on_air_successful && !on_air_previously_successful && this.proclaim_auth_required) {
+				this.getAuthToken()
+			}
+		} catch (error) {
+			// Something went wrong obtaining on-air status - can't connect to Proclaim
+			this.on_air_successful = false
+			this.on_air = false
+			this.on_air_session_id = ''
+			this.instance.setVariableValues({
+				on_air: false,
+			})
+			this.instance.checkFeedbacks('on_air')
+			this.setModuleStatus()
+		}
+	}
+
+	// Get an authentication token from Proclaim
+	async getAuthToken() {
+		const url = `http://${this.ip}:52195/appCommand/authenticate`
+		var data
+		try {
+			data = await got
+				.post(url, {
+					timeout: {
+						request: 1000,
+					},
+					retry: {
+						limit: 0,
+					},
+					json: {
+						Password: this.password,
+					},
+				})
+				.text()
+			// }).json();
+			// Calling json() returns a ERR_BODY_PARSE_FAILURE, I think because Proclaim is returning
+			// content-type: text/html rather than application/json
+
+			// Maybe because we're calling text() not json(), or maybe there's some issue in the encoding of
+			// Proclaim's response, we need to strip the byte order marker before parsing. I don't like this.
+			const parsed = JSON.parse(data.replace(/^\uFEFF/, ''))
+			this.proclaim_auth_successful = true
+			this.proclaim_auth_token = parsed.proclaimAuthToken
+			this.setModuleStatus()
+		} catch (error) {
+			if (error.response && error.response.statusCode == 401 && this.proclaim_auth_required) {
+				this.proclaim_auth_successful = false
+				this.setModuleStatus()
+			}
+		}
+	}
+
+	// Send any app command to Proclaim
+	async sendAppCommand(command, index) {
+		let url = `http://${this.ip}:52195/appCommand/perform?appCommandName=${command}`
+		if (index !== undefined) {
+			url = `${url}&index=${index}`
+		}
+
+		const options = {
+			timeout: {
+				request: 1000,
+			},
+			retry: {
+				limit: 0,
+			},
+		}
+
+		if (this.proclaim_auth_required) {
+			if (!this.proclaim_auth_successful) {
+				return
+			}
+
+			options.headers = {
+				ProclaimAuthToken: this.proclaim_auth_token,
+			}
+
+			// This shouldn't be necessary... but it is, for now.
+			// Proclaim requires the ProclaimAuthToken header name to be CamelCase, though
+			// the HTTP spec says header names are case-insensitive.
+			options.hooks = {
+				beforeRequest: [
+					(options) => {
+						options.headers['ProclaimAuthToken'] = options.headers['proclaimauthtoken']
+					},
+				],
+			}
+		}
+
+		try {
+			const data = (await got(url, options).text()).replace(/^\uFEFF/, '')
+			if (data != 'success') {
+				this.log('debug', `Unexpected response from Proclaim: ${data}`)
+			}
+		} catch (error) {
+			if (error.response.statusCode == 401 && this.proclaim_auth_required) {
+				this.proclaim_auth_successful = false
+				this.proclaim_auth_token = ''
+				this.setModuleStatus()
+			}
+		}
+	}
+}

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -3,7 +3,7 @@
 	"name": "logos-proclaim",
 	"shortname": "Proclaim",
 	"description": "Module for Logos Proclaim",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"license": "MIT",
 	"repository": "git+https://github.com/bitfocus/companion-module-logos-proclaim.git",
 	"bugs": "https://github.com/bitfocus/companion-module-logos-proclaim/issues",

--- a/feedbacks.js
+++ b/feedbacks.js
@@ -11,7 +11,7 @@ export const UpdateFeedbacks = async function (self) {
 				color: combineRgb(0, 0, 0),
 			},
 			callback: () => {
-				return self.on_air
+				return self.proclaimAPI.on_air
 			},
 		},
 	})

--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ import { UpdateActions } from './actions.js'
 import { UpdateFeedbacks } from './feedbacks.js'
 import { UpdateVariableDefinitions } from './variables.js'
 import { UpdatePresets } from './presets.js'
-import got from 'got'
+import { ProclaimAPI } from './api.js'
 
 class ProclaimInstance extends InstanceBase {
 	constructor(internal) {
@@ -17,33 +17,17 @@ class ProclaimInstance extends InstanceBase {
 
 		this.updateStatus(InstanceStatus.Connecting)
 
-		// Reference data
-		this.song_parts = [
-			{ id: 0, label: 'Verse', path: 'verse' },
-			{ id: 1, label: 'Chorus', path: 'chorus' },
-			{ id: 2, label: 'Bridge', path: 'bridge' },
-			{ id: 3, label: 'Prechorus', displayLabel: 'Pre\nchorus', path: 'prechorus' },
-			{ id: 4, label: 'Interlude', displayLabel: 'Inter-lude', path: 'interlude' },
-			{ id: 5, label: 'Tag', path: 'tag' },
-			{ id: 6, label: 'Ending', path: 'ending' },
-		]
-
 		this.updateActions() // Export actions
 		this.updateFeedbacks() // Export feedbacks
 		this.updateVariableDefinitions() // Export variable definitions
 		this.updatePresets() // Export presets
 
-		// Initialise state
+		this.proclaimAPI = new ProclaimAPI(this)
+
+		// Initialise variables
 		this.setVariableValues({
 			on_air: false,
 		})
-		this.on_air = false // Is Proclaim "On Air"?
-		this.on_air_session_id = '' // Proclaim On Air Session ID
-		this.on_air_successful = false // Were we able to connect to check Proclaim's On Air status?
-		this.onair_poll_interval = undefined // The interval ID for polling On Air status
-		this.proclaim_auth_required = false // Does Proclaim require authentication for App Commands?
-		this.proclaim_auth_successful = false // Were we able to authenticate to Proclaim?
-		this.proclaim_auth_token = '' // Proclaim authentication token
 
 		// Process module config
 		await this.configUpdated(config)
@@ -51,198 +35,14 @@ class ProclaimInstance extends InstanceBase {
 
 	// When module gets deleted
 	async destroy() {
-		if (this.onair_poll_interval !== undefined) {
-			clearInterval(this.onair_poll_interval)
-		}
+		this.proclaimAPI.destroy()
 	}
 
 	// When module config updated
 	async configUpdated(config) {
 		this.config = config
 
-		// Initialise on-air polling
-		if (this.onair_poll_interval !== undefined) {
-			clearInterval(this.onair_poll_interval)
-		}
-		this.init_onair_poll()
-
-		// Does Proclaim require authentication?
-		this.proclaim_auth_required = config.ip != '127.0.0.1'
-		if (this.proclaim_auth_required) {
-			// Ask for an auth token
-			this.getAuthToken()
-		}
-	}
-
-	// Look at the various status flags and determine the overall module connection status
-	setModuleStatus() {
-		if (!this.config.ip) {
-			this.updateStatus(InstanceStatus.BadConfig, 'IP not specified')
-			return
-		}
-
-		if (!this.on_air_successful) {
-			this.updateStatus(InstanceStatus.Disconnected, 'Could not connect to Proclaim')
-			return
-		}
-
-		if (this.proclaim_auth_required && !this.proclaim_auth_successful) {
-			this.updateStatus(InstanceStatus.ConnectionFailure, 'Proclaim authentication unsuccessful')
-			return
-		}
-
-		this.updateStatus(InstanceStatus.Ok)
-	}
-
-	// Set up the regular polling of on-air status
-	init_onair_poll() {
-		this.onair_poll_interval = setInterval(() => {
-			this.onair_poll()
-		}, 1000)
-		this.onair_poll()
-	}
-
-	// Poll for on-air status
-	async onair_poll() {
-		if (!this.config.ip) {
-			this.setModuleStatus()
-			return
-		}
-
-		const url = `http://${this.config.ip}:52195/onair/session`
-		const on_air_previously_successful = this.on_air_successful
-
-		try {
-			const data = await got(url, {
-				timeout: {
-					request: 1000,
-				},
-				retry: {
-					limit: 0,
-				},
-			}).text()
-
-			this.on_air_successful = true
-
-			// If we got a session ID back, we're on air! If we got blank, we're off air
-			if (data.length > 30) {
-				this.on_air = true
-				this.on_air_session_id = data
-				this.setVariableValues({
-					on_air: true,
-				})
-			} else {
-				this.on_air = false
-				this.on_air_session_id = ''
-				this.setVariableValues({
-					on_air: false,
-				})
-			}
-			this.checkFeedbacks('on_air')
-			this.setModuleStatus()
-
-			// If Proclaim is now responding and wasn't previously, try to authenticate
-			if (this.on_air_successful && !on_air_previously_successful && this.proclaim_auth_required) {
-				this.getAuthToken()
-			}
-		} catch (error) {
-			// Something went wrong obtaining on-air status - can't connect to Proclaim
-			this.on_air_successful = false
-			this.on_air = false
-			this.on_air_session_id = ''
-			this.setVariableValues({
-				on_air: 0,
-			})
-			this.checkFeedbacks('on_air')
-			this.setModuleStatus()
-		}
-	}
-
-	// Send any app command to Proclaim
-	async sendAppCommand(command, index) {
-		let url = `http://${this.config.ip}:52195/appCommand/perform?appCommandName=${command}`
-		if (index !== undefined) {
-			url = `${url}&index=${index}`
-		}
-
-		const options = {
-			timeout: {
-				request: 1000,
-			},
-			retry: {
-				limit: 0,
-			},
-		}
-
-		if (this.proclaim_auth_required) {
-			if (!this.proclaim_auth_successful) {
-				return
-			}
-
-			options.headers = {
-				ProclaimAuthToken: this.proclaim_auth_token,
-			}
-
-			// This shouldn't be necessary... but it is, for now.
-			// Proclaim requires the ProclaimAuthToken header name to be CamelCase, though
-			// the HTTP spec says header names are case-insensitive.
-			options.hooks = {
-				beforeRequest: [
-					(options) => {
-						options.headers['ProclaimAuthToken'] = options.headers['proclaimauthtoken']
-					},
-				],
-			}
-		}
-
-		try {
-			const data = (await got(url, options).text()).replace(/^\uFEFF/, '')
-			if (data != 'success') {
-				this.log('debug', `Unexpected response from Proclaim: ${data}`)
-			}
-		} catch (error) {
-			if (error.response.statusCode == 401 && this.proclaim_auth_required) {
-				this.proclaim_auth_successful = false
-				this.proclaim_auth_token = ''
-				this.setModuleStatus()
-			}
-		}
-	}
-
-	// Get an authentication token from Proclaim
-	async getAuthToken() {
-		const url = `http://${this.config.ip}:52195/appCommand/authenticate`
-		var data
-		try {
-			data = await got
-				.post(url, {
-					timeout: {
-						request: 1000,
-					},
-					retry: {
-						limit: 0,
-					},
-					json: {
-						Password: this.config.password,
-					},
-				})
-				.text()
-			// }).json();
-			// Calling json() returns a ERR_BODY_PARSE_FAILURE, I think because Proclaim is returning
-			// content-type: text/html rather than application/json
-
-			// Maybe because we're calling text() not json(), or maybe there's some issue in the encoding of
-			// Proclaim's response, we need to strip the byte order marker before parsing. I don't like this.
-			const parsed = JSON.parse(data.replace(/^\uFEFF/, ''))
-			this.proclaim_auth_successful = true
-			this.proclaim_auth_token = parsed.proclaimAuthToken
-			this.setModuleStatus()
-		} catch (error) {
-			if (error.response && error.response.statusCode == 401 && this.proclaim_auth_required) {
-				this.proclaim_auth_successful = false
-				this.setModuleStatus()
-			}
-		}
+		this.proclaimAPI.configure()
 	}
 
 	// Return config fields for web config

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "logos-proclaim",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"main": "main.js",
 	"type": "module",
 	"scripts": {

--- a/presets.js
+++ b/presets.js
@@ -1,4 +1,4 @@
-import { songParts, simpleActions } from './refdata.js'
+import { SONG_PARTS, SIMPLE_ACTIONS } from './refdata.js'
 import { combineRgb } from '@companion-module/base'
 
 export const UpdatePresets = async function (self) {
@@ -40,12 +40,13 @@ export const UpdatePresets = async function (self) {
 		},
 	}
 
-	for (var preset in simpleActions) {
-		let id = simpleActions[preset].id
-		let name = simpleActions[preset].name
-		let category = simpleActions[preset].category
-		let text = simpleActions[preset].text
-		let size = simpleActions[preset].size
+	// Add simple action presets, using the list from refdata.js
+	for (var preset in SIMPLE_ACTIONS) {
+		let id = SIMPLE_ACTIONS[preset].id
+		let name = SIMPLE_ACTIONS[preset].name
+		let category = SIMPLE_ACTIONS[preset].category
+		let text = SIMPLE_ACTIONS[preset].text
+		let size = SIMPLE_ACTIONS[preset].size
 		presets[id] = {
 			type: 'button',
 			category: category,
@@ -69,19 +70,21 @@ export const UpdatePresets = async function (self) {
 	}
 
 	// Song Parts
-	for (var part in songParts) {
-		if (songParts[part].label == 'Verse') {
+	for (var part in SONG_PARTS) {
+		let partId = SONG_PARTS[part].id
+		let label = SONG_PARTS[part].label
+		let displayLabel = SONG_PARTS[part].displayLabel ? SONG_PARTS[part].displayLabel : SONG_PARTS[part].label
+
+		if (label == 'Verse') {
 			for (var v = 1; v < 10; v++) {
-				const id = `song_part_${songParts[part].path}_${v}`
-				presets[id] = {
+				const presetId = `song_part_${label.toLowerCase()}_${v}`
+				presets[presetId] = {
 					type: 'button',
 					category: 'Song Parts',
-					name: `${songParts[part].label} ${v}`,
+					name: `${label} ${v}`,
 					style: {
 						...style,
-						text: songParts[part].displayLabel
-							? `${songParts[part].displayLabel}\\n${v}`
-							: `${songParts[part].label}\\n${v}`,
+						text: `${displayLabel}\\n${v}`,
 					},
 					steps: [
 						{
@@ -89,7 +92,7 @@ export const UpdatePresets = async function (self) {
 								{
 									actionId: 'go_to_song_part',
 									options: {
-										song_part: songParts[part].id,
+										song_part: partId,
 										item_index: v,
 									},
 								},
@@ -100,14 +103,14 @@ export const UpdatePresets = async function (self) {
 				}
 			}
 		} else {
-			const id = `song_part_${songParts[part].path}`
-			presets[id] = {
+			const presetId = `song_part_${label.toLowerCase()}`
+			presets[presetId] = {
 				type: 'button',
 				category: 'Song Parts',
-				name: songParts[part].label,
+				name: label,
 				style: {
 					...style,
-					text: songParts[part].displayLabel ? songParts[part].displayLabel : songParts[part].label,
+					text: displayLabel,
 				},
 				steps: [
 					{
@@ -115,7 +118,7 @@ export const UpdatePresets = async function (self) {
 							{
 								actionId: 'go_to_song_part',
 								options: {
-									song_part: songParts[part].id,
+									song_part: partId,
 									item_index: 1,
 								},
 							},

--- a/presets.js
+++ b/presets.js
@@ -42,18 +42,18 @@ export const UpdatePresets = async function (self) {
 
 	// Add simple action presets, using the list from refdata.js
 	for (var preset in SIMPLE_ACTIONS) {
-		let id = SIMPLE_ACTIONS[preset].id
+		let id = SIMPLE_ACTIONS[preset].name.split(' ').join('_').toLowerCase()
 		let name = SIMPLE_ACTIONS[preset].name
 		let category = SIMPLE_ACTIONS[preset].category
-		let text = SIMPLE_ACTIONS[preset].text
-		let size = SIMPLE_ACTIONS[preset].size
+		let text = SIMPLE_ACTIONS[preset].text ? SIMPLE_ACTIONS[preset].text : SIMPLE_ACTIONS[preset].name
+		let size = SIMPLE_ACTIONS[preset].size ? SIMPLE_ACTIONS[preset].size : 18
 		presets[id] = {
 			type: 'button',
 			category: category,
 			name: name,
 			style: {
 				...style,
-				size: size ? size : 18,
+				size: size,
 				text: text,
 			},
 			steps: [

--- a/presets.js
+++ b/presets.js
@@ -1,3 +1,4 @@
+import { song_parts } from './refdata.js'
 import { combineRgb } from '@companion-module/base'
 
 export const UpdatePresets = async function (self) {
@@ -143,19 +144,19 @@ export const UpdatePresets = async function (self) {
 	}
 
 	// Song Parts
-	for (var part in self.song_parts) {
-		if (self.song_parts[part].label == 'Verse') {
+	for (var part in song_parts) {
+		if (song_parts[part].label == 'Verse') {
 			for (var v = 1; v < 10; v++) {
-				const id = `song_part_${self.song_parts[part].path}_${v}`
+				const id = `song_part_${song_parts[part].path}_${v}`
 				presets[id] = {
 					type: 'button',
 					category: 'Song Parts',
-					name: `${self.song_parts[part].label} ${v}`,
+					name: `${song_parts[part].label} ${v}`,
 					style: {
 						...style,
-						text: self.song_parts[part].displayLabel
-							? `${self.song_parts[part].displayLabel}\\n${v}`
-							: `${self.song_parts[part].label}\\n${v}`,
+						text: song_parts[part].displayLabel
+							? `${song_parts[part].displayLabel}\\n${v}`
+							: `${song_parts[part].label}\\n${v}`,
 					},
 					steps: [
 						{
@@ -163,7 +164,7 @@ export const UpdatePresets = async function (self) {
 								{
 									actionId: 'go_to_song_part',
 									options: {
-										song_part: self.song_parts[part].id,
+										song_part: song_parts[part].id,
 										item_index: v,
 									},
 								},
@@ -174,14 +175,14 @@ export const UpdatePresets = async function (self) {
 				}
 			}
 		} else {
-			const id = `song_part_${self.song_parts[part].path}`
+			const id = `song_part_${song_parts[part].path}`
 			presets[id] = {
 				type: 'button',
 				category: 'Song Parts',
-				name: self.song_parts[part].label,
+				name: song_parts[part].label,
 				style: {
 					...style,
-					text: self.song_parts[part].displayLabel ? self.song_parts[part].displayLabel : self.song_parts[part].label,
+					text: song_parts[part].displayLabel ? song_parts[part].displayLabel : song_parts[part].label,
 				},
 				steps: [
 					{
@@ -189,7 +190,7 @@ export const UpdatePresets = async function (self) {
 							{
 								actionId: 'go_to_song_part',
 								options: {
-									song_part: self.song_parts[part].id,
+									song_part: song_parts[part].id,
 									item_index: 1,
 								},
 							},

--- a/presets.js
+++ b/presets.js
@@ -1,4 +1,4 @@
-import { song_parts } from './refdata.js'
+import { songParts, simpleActions } from './refdata.js'
 import { combineRgb } from '@companion-module/base'
 
 export const UpdatePresets = async function (self) {
@@ -40,87 +40,12 @@ export const UpdatePresets = async function (self) {
 		},
 	}
 
-	const simplePresets = [
-		// On/Off Air
-		{ id: 'go_on_air', name: 'Go On Air', category: 'On Air', text: 'Go On Air' },
-		{ id: 'go_off_air', name: 'Go Off Air', category: 'On Air', text: 'Go Off Air' },
-
-		// Slides
-		{ id: 'previous_slide', name: 'Previous Slide', category: 'Slides', text: 'Prev\nSlide' },
-		{ id: 'next_slide', name: 'Next Slide', category: 'Slides', text: 'Next\nSlide' },
-		{ id: 'previous_service_item', name: 'Previous Service Item', category: 'Slides', text: 'Prev\nItem' },
-		{ id: 'next_service_item', name: 'Next Service Item', category: 'Slides', text: 'Next\nItem' },
-
-		// Service Parts
-		{ id: 'start_pre_service', name: 'Start Pre Service', category: 'Service Parts', text: 'Pre Service' },
-		{ id: 'start_warm_up', name: 'Start Warm Up', category: 'Service Parts', text: 'Warm Up' },
-		{ id: 'start_service', name: 'Start Service', category: 'Service Parts', text: 'Service' },
-		{ id: 'start_post_service', name: 'Start Post Service', category: 'Service Parts', text: 'Post Service' },
-
-		// Media
-		{ id: 'previous_audio_item', name: 'Previous Audio Item', category: 'Media', text: 'Prev\nAudio' },
-		{ id: 'next_audio_item', name: 'Next Audio Item', category: 'Media', text: 'Next\nAudio' },
-		{ id: 'video_play', name: 'Video Play', category: 'Media', text: 'Video\nPlay' },
-		{ id: 'video_pause', name: 'Video Pause', category: 'Media', text: 'Video\nPause' },
-		{ id: 'video_restart', name: 'Video Restart', category: 'Media', text: 'Video\nRestart' },
-
-		// Quick Screens
-		{ id: 'show_blank_quick_screen', name: 'Show Blank Quick Screen', category: 'Quick Screens', text: 'Blank' },
-		{ id: 'show_logo_quick_screen', name: 'Show Logo Quick Screen', category: 'Quick Screens', text: 'Logo' },
-		{ id: 'show_no_text_quick_screen', name: 'Show No Text Quick Screen', category: 'Quick Screens', text: 'No Text' },
-		{
-			id: 'show_floating_hearts_quick_screen',
-			name: 'Show Floating Hearts Quick Screen',
-			category: 'Quick Screens',
-			text: 'Floating Hearts',
-		},
-		{
-			id: 'show_floating_amens_quick_screen',
-			name: 'Show Floating Amens Quick Screen',
-			category: 'Quick Screens',
-			text: 'Floating Amens',
-		},
-		{
-			id: 'show_amen_quick_screen',
-			name: 'Show Amen Quick Screen',
-			category: 'Quick Screens',
-			text: 'Amen',
-		},
-		{
-			id: 'show_hallelujah_quick_screen',
-			name: 'Show Hallelujah Quick Screen',
-			category: 'Quick Screens',
-			text: 'Hallelujah',
-			size: 14,
-		},
-		{
-			id: 'show_praise_the_lord_quick_screen',
-			name: 'Show Praise The Lord Quick Screen',
-			category: 'Quick Screens',
-			text: 'Praise The Lord',
-			size: 14,
-		},
-		{
-			id: 'show_he_is_risen_quick_screen',
-			name: 'Show He Is Risen Quick Screen',
-			category: 'Quick Screens',
-			text: 'He Is Risen',
-		},
-		{
-			id: 'show_he_is_risen_indeed_quick_screen',
-			name: 'Show He Is Risen Indeed Quick Screen',
-			category: 'Quick Screens',
-			text: 'He Is Risen Indeed',
-			size: 14,
-		},
-	]
-
-	for (var preset in simplePresets) {
-		let id = simplePresets[preset].id
-		let name = simplePresets[preset].name
-		let category = simplePresets[preset].category
-		let text = simplePresets[preset].text
-		let size = simplePresets[preset].size
+	for (var preset in simpleActions) {
+		let id = simpleActions[preset].id
+		let name = simpleActions[preset].name
+		let category = simpleActions[preset].category
+		let text = simpleActions[preset].text
+		let size = simpleActions[preset].size
 		presets[id] = {
 			type: 'button',
 			category: category,
@@ -144,19 +69,19 @@ export const UpdatePresets = async function (self) {
 	}
 
 	// Song Parts
-	for (var part in song_parts) {
-		if (song_parts[part].label == 'Verse') {
+	for (var part in songParts) {
+		if (songParts[part].label == 'Verse') {
 			for (var v = 1; v < 10; v++) {
-				const id = `song_part_${song_parts[part].path}_${v}`
+				const id = `song_part_${songParts[part].path}_${v}`
 				presets[id] = {
 					type: 'button',
 					category: 'Song Parts',
-					name: `${song_parts[part].label} ${v}`,
+					name: `${songParts[part].label} ${v}`,
 					style: {
 						...style,
-						text: song_parts[part].displayLabel
-							? `${song_parts[part].displayLabel}\\n${v}`
-							: `${song_parts[part].label}\\n${v}`,
+						text: songParts[part].displayLabel
+							? `${songParts[part].displayLabel}\\n${v}`
+							: `${songParts[part].label}\\n${v}`,
 					},
 					steps: [
 						{
@@ -164,7 +89,7 @@ export const UpdatePresets = async function (self) {
 								{
 									actionId: 'go_to_song_part',
 									options: {
-										song_part: song_parts[part].id,
+										song_part: songParts[part].id,
 										item_index: v,
 									},
 								},
@@ -175,14 +100,14 @@ export const UpdatePresets = async function (self) {
 				}
 			}
 		} else {
-			const id = `song_part_${song_parts[part].path}`
+			const id = `song_part_${songParts[part].path}`
 			presets[id] = {
 				type: 'button',
 				category: 'Song Parts',
-				name: song_parts[part].label,
+				name: songParts[part].label,
 				style: {
 					...style,
-					text: song_parts[part].displayLabel ? song_parts[part].displayLabel : song_parts[part].label,
+					text: songParts[part].displayLabel ? songParts[part].displayLabel : songParts[part].label,
 				},
 				steps: [
 					{
@@ -190,7 +115,7 @@ export const UpdatePresets = async function (self) {
 							{
 								actionId: 'go_to_song_part',
 								options: {
-									song_part: song_parts[part].id,
+									song_part: songParts[part].id,
 									item_index: 1,
 								},
 							},

--- a/refdata.js
+++ b/refdata.js
@@ -1,0 +1,10 @@
+// Reference data used in setting up actions and presets
+export const song_parts = [
+	{ id: 0, label: 'Verse', path: 'verse' },
+	{ id: 1, label: 'Chorus', path: 'chorus' },
+	{ id: 2, label: 'Bridge', path: 'bridge' },
+	{ id: 3, label: 'Prechorus', displayLabel: 'Pre\nchorus', path: 'prechorus' },
+	{ id: 4, label: 'Interlude', displayLabel: 'Inter-lude', path: 'interlude' },
+	{ id: 5, label: 'Tag', path: 'tag' },
+	{ id: 6, label: 'Ending', path: 'ending' },
+]

--- a/refdata.js
+++ b/refdata.js
@@ -11,155 +11,146 @@ export const SONG_PARTS = [
 	{ id: 6, label: 'Ending' },
 ]
 
-// Simple actions each of which has an action and matching preset, corresponding to a single Proclaim app command
+// Simple actions, each of which has an action and matching preset, corresponding to a single Proclaim app command
+//
+// The action and preset IDs will be the name, converted to snake_case
+// The preset text will be the name, unless overridden below
+// The preset text size will be 18, unless overridden below
+// The Proclaim API App Command will be the name converted to CamelCase, unless overridden below
 export const SIMPLE_ACTIONS = [
 	// On/Off Air
-	{ id: 'go_on_air', name: 'Go On Air', category: 'On Air', text: 'Go On Air', appCommand: 'GoOnAir' },
-	{ id: 'go_off_air', name: 'Go Off Air', category: 'On Air', text: 'Go Off Air', appCommand: 'GoOffAir' },
+	{
+		name: 'Go On Air',
+		category: 'On Air',
+	},
+	{
+		name: 'Go Off Air',
+		category: 'On Air',
+	},
 
 	// Slides
 	{
-		id: 'previous_slide',
 		name: 'Previous Slide',
 		category: 'Slides',
 		text: 'Prev\nSlide',
-		appCommand: 'PreviousSlide',
 	},
-	{ id: 'next_slide', name: 'Next Slide', category: 'Slides', text: 'Next\nSlide', appCommand: 'NextSlide' },
 	{
-		id: 'previous_service_item',
+		name: 'Next Slide',
+		category: 'Slides',
+		text: 'Next\nSlide',
+	},
+	{
 		name: 'Previous Service Item',
 		category: 'Slides',
 		text: 'Prev\nItem',
-		appCommand: 'PreviousServiceItem',
 	},
 	{
-		id: 'next_service_item',
 		name: 'Next Service Item',
 		category: 'Slides',
 		text: 'Next\nItem',
-		appCommand: 'NextServiceItem',
 	},
 
 	// Service Parts
 	{
-		id: 'start_pre_service',
 		name: 'Start Pre Service',
 		category: 'Service Parts',
 		text: 'Pre Service',
-		appCommand: 'StartPreService',
 	},
 	{
-		id: 'start_warm_up',
 		name: 'Start Warm Up',
 		category: 'Service Parts',
 		text: 'Warm Up',
-		appCommand: 'StartWarmUp',
 	},
 	{
-		id: 'start_service',
 		name: 'Start Service',
 		category: 'Service Parts',
 		text: 'Service',
-		appCommand: 'StartService',
 	},
 	{
-		id: 'start_post_service',
 		name: 'Start Post Service',
 		category: 'Service Parts',
 		text: 'Post Service',
-		appCommand: 'StartPostService',
 	},
 
 	// Media
 	{
-		id: 'previous_audio_item',
 		name: 'Previous Audio Item',
 		category: 'Media',
 		text: 'Prev\nAudio',
 		appCommand: 'PreviousPreviousAudioItem', // (sic.)
 	},
 	{
-		id: 'next_audio_item',
 		name: 'Next Audio Item',
 		category: 'Media',
 		text: 'Next\nAudio',
-		appCommand: 'NextAudioItem',
 	},
-	{ id: 'video_play', name: 'Video Play', category: 'Media', text: 'Video\nPlay', appCommand: 'VideoPlay' },
-	{ id: 'video_pause', name: 'Video Pause', category: 'Media', text: 'Video\nPause', appCommand: 'VideoPause' },
-	{ id: 'video_restart', name: 'Video Restart', category: 'Media', text: 'Video\nRestart', appCommand: 'VideoRestart' },
-	// { id: 'video_rewind', name: 'Video Rewind', category: 'Media', text: 'Video\nRewind', appCommand: 'VideoRestart' },
-	// { id: 'video_fast_forward', name: 'Video Fast Forward', category: 'Media', text: 'Video\nFast\nForward', appCommand: 'VideoFastForward' },
+	{
+		name: 'Video Play',
+		category: 'Media',
+		text: 'Video\nPlay',
+	},
+	{
+		name: 'Video Pause',
+		category: 'Media',
+		text: 'Video\nPause',
+	},
+	{
+		name: 'Video Restart',
+		category: 'Media',
+		text: 'Video\nRestart',
+	},
+	// { name: 'Video Rewind', category: 'Media', text: 'Video\nRewind' },
+	// { name: 'Video Fast Forward', category: 'Media', text: 'Video\nFast\nForward' },
 
 	// Quick Screens
 	{
-		id: 'show_blank_quick_screen',
 		name: 'Show Blank Quick Screen',
 		category: 'Quick Screens',
 		text: 'Blank',
-		appCommand: 'ShowBlankQuickScreen',
 	},
 	{
-		id: 'show_logo_quick_screen',
 		name: 'Show Logo Quick Screen',
 		category: 'Quick Screens',
 		text: 'Logo',
-		appCommand: 'ShowLogoQuickScreen',
 	},
 	{
-		id: 'show_no_text_quick_screen',
 		name: 'Show No Text Quick Screen',
 		category: 'Quick Screens',
 		text: 'No Text',
-		appCommand: 'ShowNoTextQuickScreen',
 	},
 	{
-		id: 'show_floating_hearts_quick_screen',
 		name: 'Show Floating Hearts Quick Screen',
 		category: 'Quick Screens',
 		text: 'Floating Hearts',
-		appCommand: 'ShowFloatingHeartsQuickScreen',
 	},
 	{
-		id: 'show_floating_amens_quick_screen',
 		name: 'Show Floating Amens Quick Screen',
 		category: 'Quick Screens',
 		text: 'Floating Amens',
-		appCommand: 'ShowFloatingAmensQuickScreen',
 	},
 	{
-		id: 'show_amen_quick_screen',
 		name: 'Show Amen Quick Screen',
 		category: 'Quick Screens',
 		text: 'Amen',
-		appCommand: 'ShowAmenQuickScreen',
 	},
 	{
-		id: 'show_hallelujah_quick_screen',
 		name: 'Show Hallelujah Quick Screen',
 		category: 'Quick Screens',
 		text: 'Hallelujah',
 		size: 14,
-		appCommand: 'ShowHallelujahQuickScreen',
 	},
 	{
-		id: 'show_praise_the_lord_quick_screen',
 		name: 'Show Praise The Lord Quick Screen',
 		category: 'Quick Screens',
 		text: 'Praise The Lord',
 		size: 14,
-		appCommand: 'ShowPraiseTheLordQuickScreen',
 	},
 	{
-		id: 'show_he_is_risen_quick_screen',
 		name: 'Show He Is Risen Quick Screen',
 		category: 'Quick Screens',
 		text: 'He Is Risen',
-		appCommand: 'ShowHeIsRisenQuickScreen',
 	},
 	{
-		id: 'show_he_is_risen_indeed_quick_screen',
 		name: 'Show He Is Risen Indeed Quick Screen',
 		category: 'Quick Screens',
 		text: 'He Is Risen Indeed',

--- a/refdata.js
+++ b/refdata.js
@@ -1,5 +1,5 @@
 // Reference data used in setting up actions and presets
-export const song_parts = [
+export const songParts = [
 	{ id: 0, label: 'Verse', path: 'verse' },
 	{ id: 1, label: 'Chorus', path: 'chorus' },
 	{ id: 2, label: 'Bridge', path: 'bridge' },
@@ -7,4 +7,160 @@ export const song_parts = [
 	{ id: 4, label: 'Interlude', displayLabel: 'Inter-lude', path: 'interlude' },
 	{ id: 5, label: 'Tag', path: 'tag' },
 	{ id: 6, label: 'Ending', path: 'ending' },
+]
+
+export const simpleActions = [
+	// On/Off Air
+	{ id: 'go_on_air', name: 'Go On Air', category: 'On Air', text: 'Go On Air', appCommand: 'GoOnAir' },
+	{ id: 'go_off_air', name: 'Go Off Air', category: 'On Air', text: 'Go Off Air', appCommand: 'GoOffAir' },
+
+	// Slides
+	{
+		id: 'previous_slide',
+		name: 'Previous Slide',
+		category: 'Slides',
+		text: 'Prev\nSlide',
+		appCommand: 'PreviousSlide',
+	},
+	{ id: 'next_slide', name: 'Next Slide', category: 'Slides', text: 'Next\nSlide', appCommand: 'NextSlide' },
+	{
+		id: 'previous_service_item',
+		name: 'Previous Service Item',
+		category: 'Slides',
+		text: 'Prev\nItem',
+		appCommand: 'PreviousServiceItem',
+	},
+	{
+		id: 'next_service_item',
+		name: 'Next Service Item',
+		category: 'Slides',
+		text: 'Next\nItem',
+		appCommand: 'NextServiceItem',
+	},
+
+	// Service Parts
+	{
+		id: 'start_pre_service',
+		name: 'Start Pre Service',
+		category: 'Service Parts',
+		text: 'Pre Service',
+		appCommand: 'StartPreService',
+	},
+	{
+		id: 'start_warm_up',
+		name: 'Start Warm Up',
+		category: 'Service Parts',
+		text: 'Warm Up',
+		appCommand: 'StartWarmUp',
+	},
+	{
+		id: 'start_service',
+		name: 'Start Service',
+		category: 'Service Parts',
+		text: 'Service',
+		appCommand: 'StartService',
+	},
+	{
+		id: 'start_post_service',
+		name: 'Start Post Service',
+		category: 'Service Parts',
+		text: 'Post Service',
+		appCommand: 'StartPostService',
+	},
+
+	// Media
+	{
+		id: 'previous_audio_item',
+		name: 'Previous Audio Item',
+		category: 'Media',
+		text: 'Prev\nAudio',
+		appCommand: 'PreviousPreviousAudioItem', // (sic.)
+	},
+	{
+		id: 'next_audio_item',
+		name: 'Next Audio Item',
+		category: 'Media',
+		text: 'Next\nAudio',
+		appCommand: 'NextAudioItem',
+	},
+	{ id: 'video_play', name: 'Video Play', category: 'Media', text: 'Video\nPlay', appCommand: 'VideoPlay' },
+	{ id: 'video_pause', name: 'Video Pause', category: 'Media', text: 'Video\nPause', appCommand: 'VideoPause' },
+	{ id: 'video_restart', name: 'Video Restart', category: 'Media', text: 'Video\nRestart', appCommand: 'VideoRestart' },
+	// { id: 'video_rewind', name: 'Video Rewind', category: 'Media', text: 'Video\nRewind', appCommand: 'VideoRestart' },
+	// { id: 'video_fast_forward', name: 'Video Fast Forward', category: 'Media', text: 'Video\nFast\nForward', appCommand: 'VideoFastForward' },
+
+	// Quick Screens
+	{
+		id: 'show_blank_quick_screen',
+		name: 'Show Blank Quick Screen',
+		category: 'Quick Screens',
+		text: 'Blank',
+		appCommand: 'ShowBlankQuickScreen',
+	},
+	{
+		id: 'show_logo_quick_screen',
+		name: 'Show Logo Quick Screen',
+		category: 'Quick Screens',
+		text: 'Logo',
+		appCommand: 'ShowLogoQuickScreen',
+	},
+	{
+		id: 'show_no_text_quick_screen',
+		name: 'Show No Text Quick Screen',
+		category: 'Quick Screens',
+		text: 'No Text',
+		appCommand: 'ShowNoTextQuickScreen',
+	},
+	{
+		id: 'show_floating_hearts_quick_screen',
+		name: 'Show Floating Hearts Quick Screen',
+		category: 'Quick Screens',
+		text: 'Floating Hearts',
+		appCommand: 'ShowFloatingHeartsQuickScreen',
+	},
+	{
+		id: 'show_floating_amens_quick_screen',
+		name: 'Show Floating Amens Quick Screen',
+		category: 'Quick Screens',
+		text: 'Floating Amens',
+		appCommand: 'ShowFloatingAmensQuickScreen',
+	},
+	{
+		id: 'show_amen_quick_screen',
+		name: 'Show Amen Quick Screen',
+		category: 'Quick Screens',
+		text: 'Amen',
+		appCommand: 'ShowAmenQuickScreen',
+	},
+	{
+		id: 'show_hallelujah_quick_screen',
+		name: 'Show Hallelujah Quick Screen',
+		category: 'Quick Screens',
+		text: 'Hallelujah',
+		size: 14,
+		appCommand: 'ShowHallelujahQuickScreen',
+	},
+	{
+		id: 'show_praise_the_lord_quick_screen',
+		name: 'Show Praise The Lord Quick Screen',
+		category: 'Quick Screens',
+		text: 'Praise The Lord',
+		size: 14,
+		appCommand: 'ShowPraiseTheLordQuickScreen',
+	},
+	{
+		id: 'show_he_is_risen_quick_screen',
+		name: 'Show He Is Risen Quick Screen',
+		category: 'Quick Screens',
+		text: 'He Is Risen',
+		appCommand: 'ShowHeIsRisenQuickScreen',
+	},
+	{
+		id: 'show_he_is_risen_indeed_quick_screen',
+		name: 'Show He Is Risen Indeed Quick Screen',
+		category: 'Quick Screens',
+		text: 'He Is Risen Indeed',
+		size: 14,
+		appCommand: 'ShowHeIsRisenWhiteQuickScreen', // (sic.)
+	},
 ]

--- a/refdata.js
+++ b/refdata.js
@@ -99,8 +99,17 @@ export const SIMPLE_ACTIONS = [
 		category: 'Media',
 		text: 'Video\nRestart',
 	},
-	// { name: 'Video Rewind', category: 'Media', text: 'Video\nRewind' },
-	// { name: 'Video Fast Forward', category: 'Media', text: 'Video\nFast\nForward' },
+	{
+		name: 'Video Rewind',
+		category: 'Media',
+		text: 'Video\nRewind',
+	},
+	{
+		name: 'Video Fast Forward',
+		category: 'Media',
+		text: 'Video\nFast\nForward',
+		size: 14,
+	},
 
 	// Quick Screens
 	{

--- a/refdata.js
+++ b/refdata.js
@@ -1,15 +1,18 @@
 // Reference data used in setting up actions and presets
-export const songParts = [
-	{ id: 0, label: 'Verse', path: 'verse' },
-	{ id: 1, label: 'Chorus', path: 'chorus' },
-	{ id: 2, label: 'Bridge', path: 'bridge' },
-	{ id: 3, label: 'Prechorus', displayLabel: 'Pre\nchorus', path: 'prechorus' },
-	{ id: 4, label: 'Interlude', displayLabel: 'Inter-lude', path: 'interlude' },
-	{ id: 5, label: 'Tag', path: 'tag' },
-	{ id: 6, label: 'Ending', path: 'ending' },
+
+// Song parts - used in the go_to_song_part action and in constructing its presets
+export const SONG_PARTS = [
+	{ id: 0, label: 'Verse' },
+	{ id: 1, label: 'Chorus' },
+	{ id: 2, label: 'Bridge' },
+	{ id: 3, label: 'Prechorus', displayLabel: 'Pre\nchorus' },
+	{ id: 4, label: 'Interlude', displayLabel: 'Inter-lude' },
+	{ id: 5, label: 'Tag' },
+	{ id: 6, label: 'Ending' },
 ]
 
-export const simpleActions = [
+// Simple actions each of which has an action and matching preset, corresponding to a single Proclaim app command
+export const SIMPLE_ACTIONS = [
 	// On/Off Air
 	{ id: 'go_on_air', name: 'Go On Air', category: 'On Air', text: 'Go On Air', appCommand: 'GoOnAir' },
 	{ id: 'go_off_air', name: 'Go Off Air', category: 'On Air', text: 'Go Off Air', appCommand: 'GoOffAir' },


### PR DESCRIPTION
Add the "Video Rewind" and "Video Fast Forward" actions and presets

Various refactorings:
- Move Proclaim API calls into api.js
- Move reference data (especially the long lists of Proclaim app commands) into refdata.js