### PR TITLE
Add ShowText command to exit Quick Screens

### DIFF
--- a/refdata.js
+++ b/refdata.js
@@ -123,6 +123,11 @@ export const SIMPLE_ACTIONS = [
 		text: 'Logo',
 	},
 	{
+		name: 'Show Text',
+		category: 'Quick Screens',
+		text: 'Show Text',
+	},
+	{
 		name: 'Show No Text Quick Screen',
 		category: 'Quick Screens',
 		text: 'No Text',


### PR DESCRIPTION
Proclaim exposes an undocumented API endpoint:

/appCommand/perform?appCommandName=ShowText

In testing, this command exits the "Show No Text Quick Screen".

This does not appear to exit all Quick Screens generally, so it may not fully resolve issue #3, but it adds support for an undocumented command that is useful and currently missing from the module.

Tested locally with Proclaim and confirmed that ShowText clears the No Text Quick Screen.