### PR TITLE
Add "Show Last Slide" action and preset

### DIFF
--- a/refdata.js
+++ b/refdata.js
@@ -171,4 +171,9 @@ export const SIMPLE_ACTIONS = [
 		size: 14,
 		appCommand: 'ShowHeIsRisenWhiteQuickScreen', // (sic.)
 	},
+	{
+		name: 'Show Last Slide',
+		category: 'Quick Screens',
+		text: 'Last Slide'
+	}
 ]


### PR DESCRIPTION
An undocumented app command in the Proclaim HTTP API allows showing the last slide that had been shown before showing a quick screen.