### PR TITLE
Add "Show Custom Quick Screen" action and presets

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1,4 +1,4 @@
-import { SONG_PARTS, SIMPLE_ACTIONS } from './refdata.js'
+import { SONG_PARTS, SIMPLE_ACTIONS, CUSTOM_QUICK_SCREEN_COUNT } from './refdata.js'
 
 export const UpdateActions = function (self) {
 	let actions = {
@@ -69,6 +69,23 @@ export const UpdateActions = function (self) {
 			callback: async (event) => {
 				const part = SONG_PARTS[event.options.song_part].label
 				await self.proclaimAPI.sendAppCommand(`ShowSongLyrics${part}ByIndex`, event.options.item_index)
+			},
+		},
+
+		show_custom_quick_screen: {
+			name: 'Show Custom Quick Screen',
+			options: [
+				{
+					id: 'num',
+					type: 'number',
+					label: 'Custom Quick Screen Number',
+					default: 1,
+					min: 1,
+					max: CUSTOM_QUICK_SCREEN_COUNT,
+				},
+			],
+			callback: async (event) => {
+				await self.proclaimAPI.sendAppCommand('ShowCustomQuickScreen', event.options.num)
 			},
 		},
 	}

--- a/presets.js
+++ b/presets.js
@@ -1,4 +1,4 @@
-import { SONG_PARTS, SIMPLE_ACTIONS } from './refdata.js'
+import { SONG_PARTS, SIMPLE_ACTIONS, CUSTOM_QUICK_SCREEN_COUNT } from './refdata.js'
 import { combineRgb } from '@companion-module/base'
 
 export const UpdatePresets = async function (self) {
@@ -61,6 +61,31 @@ export const UpdatePresets = async function (self) {
 					down: [
 						{
 							actionId: id,
+						},
+					],
+					up: [],
+				},
+			],
+		}
+	}
+
+	for (var i=1; i<=CUSTOM_QUICK_SCREEN_COUNT; i++) {
+		presets[`show_custom_quick_screen_${i}`] = {
+			type: 'button',
+			category: 'Quick Screens',
+			name: `Show Custom Quick Screen ${i}`,
+			style: {
+				...style,
+				text: `Custom ${i}`
+			},
+			steps: [
+				{
+					down: [
+						{
+							actionId: 'show_custom_quick_screen',
+							options: {
+								num: i,
+							},
 						},
 					],
 					up: [],

--- a/refdata.js
+++ b/refdata.js
@@ -11,6 +11,9 @@ export const SONG_PARTS = [
 	{ id: 6, label: 'Ending' },
 ]
 
+// How many custom quick screens Proclaim supports
+export const CUSTOM_QUICK_SCREEN_COUNT = 2
+
 // Simple actions, each of which has an action and matching preset, corresponding to a single Proclaim app command
 //
 // The action and preset IDs will be the name, converted to snake_case


### PR DESCRIPTION
An undocumented app command in the Proclaim HTTP API allows showing the two custom quick screens. This PR adds an action and two presets for this.